### PR TITLE
Fixed fail2ban task

### DIFF
--- a/ansible/tasks/app/fail2ban/fail2ban.yaml
+++ b/ansible/tasks/app/fail2ban/fail2ban.yaml
@@ -1,5 +1,6 @@
 ---
 - hosts: avogadro
+  become: yes
   tasks:      
 
     - name: Remove Default Fail2ban config file


### PR DESCRIPTION
added admin privilege to the task to delete the default jail file
Solves #7 